### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/extensions.csproj
+++ b/extensions.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.7" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.8" />
   </ItemGroup>
 </Project>

--- a/extensions.csproj
+++ b/extensions.csproj
@@ -5,7 +5,7 @@
 	<DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.5" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.7" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
2 packages were updated in 1 project:
`Microsoft.Azure.WebJobs.Extensions.CosmosDB`, `Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `Microsoft.Azure.WebJobs.Extensions.CosmosDB` to `3.0.7` from `3.0.5`
`Microsoft.Azure.WebJobs.Extensions.CosmosDB 3.0.7` was published at `2020-04-24T17:58:30Z`, 5 months ago

1 project update:
Updated `extensions.csproj` to `Microsoft.Azure.WebJobs.Extensions.CosmosDB` `3.0.7` from `3.0.5`

[Microsoft.Azure.WebJobs.Extensions.CosmosDB 3.0.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.CosmosDB/3.0.7)

NuKeeper has generated a patch update of `Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator` to `1.1.8` from `1.1.0`
`Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator 1.1.8` was published at `2020-05-04T20:59:15Z`, 4 months ago

1 project update:
Updated `extensions.csproj` to `Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator` `1.1.8` from `1.1.0`

[Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator 1.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator/1.1.8)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
